### PR TITLE
Harden the starter for production use

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,4 +3,5 @@ APP_SLUG=expo-turbo-starter
 APP_SCHEME=expo-turbo-starter
 IOS_BUNDLE_IDENTIFIER=com.example.expoturbostarter
 ANDROID_PACKAGE=com.example.expoturbostarter
+# APP_ENV=development
 # EAS_PROJECT_ID=

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -5,10 +5,10 @@ runs:
   using: composite
   steps:
     - name: Install pnpm
-      uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
+      uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
 
     - name: Install Node.js
-      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+      uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
       with:
         node-version-file: .nvmrc
         cache: pnpm

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -5,10 +5,10 @@ runs:
   using: composite
   steps:
     - name: Install pnpm
-      uses: pnpm/action-setup@v4
+      uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
 
     - name: Install Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
       with:
         node-version-file: .nvmrc
         cache: pnpm

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -7,6 +7,8 @@
 - [ ] `pnpm check`
 - [ ] `pnpm expo:doctor` for Expo or dependency changes
 - [ ] `pnpm export:web` for app or UI changes
+- [ ] `pnpm check:workflows` for EAS workflow changes
+- [ ] `pnpm verify:template` for initialization, identity, workspace, or toolchain changes
 - [ ] Native development build checked for native or UI changes
 
 ## Visual changes

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
 
       - name: Set up workspace
         uses: ./.github/actions/setup
@@ -41,18 +43,23 @@ jobs:
       - name: Check Expo project health
         run: pnpm expo:doctor
 
+      - name: Validate EAS workflows
+        run: pnpm check:workflows
+
       - name: Export web app
         run: pnpm export:web
 
       - name: Audit dependencies
-        run: pnpm audit --audit-level high
+        run: pnpm audit --audit-level moderate
 
   package-tests:
     name: Shared package tests
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
 
       - name: Set up workspace
         uses: ./.github/actions/setup
@@ -63,15 +70,17 @@ jobs:
       - name: Run generator tests
         run: pnpm test:scripts
 
-      - name: Run shared package Jest suites
-        run: pnpm test:packages
+      - name: Run shared package Jest suites with coverage
+        run: pnpm test:coverage:packages
 
   app-tests:
     name: App tests
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
 
       - name: Set up workspace
         uses: ./.github/actions/setup
@@ -79,8 +88,23 @@ jobs:
       - name: Build shared packages
         run: pnpm build:packages
 
-      - name: Run app Jest suite
-        run: pnpm test:app
+      - name: Run app Jest suite with coverage
+        run: pnpm test:coverage:app
+
+  template-canary:
+    name: Generated template canary
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
+
+      - name: Set up workspace
+        uses: ./.github/actions/setup
+
+      - name: Verify a freshly initialized project
+        run: pnpm verify:template
 
   dependency-review:
     name: Dependency review
@@ -90,10 +114,12 @@ jobs:
       contents: read
     steps:
       - name: Check out repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
 
       - name: Review dependency changes
-        uses: actions/dependency-review-action@v5
+        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
         with:
           fail-on-severity: high
           license-check: true
@@ -106,11 +132,12 @@ jobs:
       contents: read
     steps:
       - name: Check out repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Scan Git history
-        uses: gitleaks/gitleaks-action@v3
+        uses: gitleaks/gitleaks-action@e0c47f4f8be36e29cdc102c57e68cb5cbf0e8d1e # v3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/native-build.yml
+++ b/.github/workflows/native-build.yml
@@ -44,6 +44,9 @@ jobs:
       - name: Generate Android project
         run: pnpm --filter @starter/mobile-app exec expo prebuild --platform android --no-install --clean
 
+      - name: Configure Gradle cache
+        uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
+
       - name: Compile Android debug app
         working-directory: apps/mobile-app/android
         run: ./gradlew assembleDebug --no-daemon

--- a/.github/workflows/native-build.yml
+++ b/.github/workflows/native-build.yml
@@ -1,0 +1,84 @@
+name: Native build
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - .github/actions/setup/**
+      - .github/workflows/native-build.yml
+      - apps/mobile-app/app.config.ts
+      - apps/mobile-app/assets/**
+      - apps/mobile-app/babel.config.js
+      - apps/mobile-app/eas.json
+      - apps/mobile-app/package.json
+      - package.json
+      - packages/ui/**
+      - pnpm-lock.yaml
+
+permissions:
+  contents: read
+
+concurrency:
+  group: native-build-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  android:
+    name: Android debug build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
+
+      - name: Install Java
+        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
+        with:
+          distribution: temurin
+          java-version: 17
+
+      - name: Set up workspace
+        uses: ./.github/actions/setup
+
+      - name: Generate Android project
+        run: pnpm --filter @starter/mobile-app exec expo prebuild --platform android --no-install --clean
+
+      - name: Compile Android debug app
+        working-directory: apps/mobile-app/android
+        run: ./gradlew assembleDebug --no-daemon
+
+  ios:
+    name: iOS simulator build
+    runs-on: macos-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
+
+      - name: Set up workspace
+        uses: ./.github/actions/setup
+
+      - name: Generate iOS project
+        run: pnpm --filter @starter/mobile-app exec expo prebuild --platform ios --no-install --clean
+
+      - name: Install CocoaPods
+        working-directory: apps/mobile-app/ios
+        run: pod install
+
+      - name: Compile iOS simulator app
+        working-directory: apps/mobile-app
+        shell: bash
+        run: |
+          workspace="$(find ios -maxdepth 1 -name '*.xcworkspace' -print -quit)"
+          scheme="$(xcodebuild -workspace "$workspace" -list -json | jq -r '.workspace.schemes[0]')"
+          test -n "$workspace"
+          test -n "$scheme"
+          xcodebuild \
+            -workspace "$workspace" \
+            -scheme "$scheme" \
+            -configuration Debug \
+            -destination 'generic/platform=iOS Simulator' \
+            CODE_SIGNING_ALLOWED=NO \
+            build

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
 node-linker=isolated
+engine-strict=true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,8 @@
 
 - Keep `apps/mobile-app/src/app` routes-only. Put screen bodies and behavior in `src/screens`.
 - The app owns native configuration, product decisions, and Unistyles registration.
+- EAS workflows live under `apps/mobile-app/.eas/workflows` and stay manual by default in the
+  unlinked template.
 - Shared UI may consume theme and utils, but must not configure global themes or import app code.
 - Utils stay runtime-independent. Do not add React or React Native dependencies there.
 - Colocate tests as `*.test.ts` or `*.test.tsx` and assert observable behavior over implementation
@@ -39,6 +41,8 @@
 - Documentation-only changes: run `pnpm format:check`.
 - Code changes: run `pnpm check`.
 - Dependency or Expo configuration changes: also run `pnpm expo:doctor` and `pnpm export:web`.
+- EAS workflow changes: also run `pnpm check:workflows`.
+- Initialization, identity, workspace, or toolchain changes: also run `pnpm verify:template`.
 - Generator changes: cover filesystem behavior with `pnpm test:scripts` and smoke-test both package
   kinds in a temporary workspace.
 - Report what was verified and call out anything that could not be run.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Changelog
+
+This file records changes that affect newly generated applications and the work required to adopt
+them in existing applications. GitHub template repositories do not update their consumers
+automatically.
+
+## 1.0.0 - 2026-07-19
+
+- Established the Expo SDK 57, React Native 0.86, Node 24, and pnpm 10 baseline.
+- Added the mobile app plus private theme, UI, and utility packages.
+- Added initialization and package generators with behavior tests.
+- Added strict lint, type, unit, coverage, dependency, secret, Expo, and web-export checks.
+- Added generated-template canary validation, native compile checks, and production configuration
+  guards.
+- Added a root recovery screen with a provider-neutral error-reporting seam.
+- Added opt-in EAS production delivery and Maestro smoke-test workflows.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,7 +26,16 @@ run `pnpm check` before you send the change. Dependency or Expo configuration ch
 ```sh
 pnpm expo:doctor
 pnpm export:web
+pnpm check:workflows
 ```
+
+If you change the setup script or any starter-wide default, run `pnpm verify:template`. It creates a
+clean copy with different branding and package scope, installs from the lockfile, reruns setup to
+prove it is idempotent, and exercises the quality, Expo, web-export, and native-prebuild paths.
+
+Changes to native configuration or native dependencies trigger real Android and iOS compilation in
+the `Native build` workflow. Run that workflow manually when a native-impacting change falls outside
+its path filters.
 
 ## Send a useful pull request
 
@@ -36,5 +45,9 @@ requests are much easier to understand and merge.
 
 Please keep product-specific services and branding out of the starter. The goal is a strong place to
 begin, not a demo app everyone has to dismantle.
+
+Starter changes are recorded in `CHANGELOG.md`. Treat the root package version as the template
+version and bump it when a released change should be discoverable by existing projects. Describe
+the adoption steps in `docs/upgrading.md` whenever copying the change requires judgment or migration.
 
 Contributions are licensed under the repository's MIT License.

--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ boundaries honest. Auth, data fetching, analytics, and every other product decis
 - `packages/ui` — accessible React Native building blocks styled with Unistyles
 - `packages/utils` — plain TypeScript helpers with no React Native dependency
 - Jest, React Native Testing Library, ESLint, Prettier, Turborepo, and GitHub Actions
+- A root recovery screen, provider-neutral error reporting seam, and production config guards
+- Manual-by-default EAS production delivery and native Maestro smoke workflows
 - A concise `AGENTS.md` that gives coding agents the same workspace rules
 
 The starter targets Expo SDK 57, React Native 0.86, Node 24, and pnpm 10. Workspace packages are
@@ -46,8 +48,8 @@ pnpm run setup --yes \
   --android-package com.acme.mobile
 ```
 
-Commit the generated `.template-initialized.json` file. It is a receipt for the non-secret choices
-made during setup, and running the command again with the same values is safe.
+Commit the generated `.template-initialized.json` file. It records the template version and the
+non-secret choices made during setup, and running the command again with the same values is safe.
 
 ## The one rule that matters
 
@@ -76,22 +78,24 @@ starter, review agent work, and adapt the instructions once the template becomes
 
 ## Commands you will actually use
 
-| Command              | What it does                                      |
-| -------------------- | ------------------------------------------------- |
-| `pnpm dev`           | Start Metro for the development client            |
-| `pnpm ios`           | Build and run the iOS app                         |
-| `pnpm android`       | Build and run the Android app                     |
-| `pnpm web`           | Start the web app                                 |
-| `pnpm test`          | Run every Jest suite                              |
-| `pnpm test:watch`    | Watch the app Jest suite                          |
-| `pnpm test:coverage` | Write coverage reports for every workspace        |
-| `pnpm generate`      | Generate a shared package                         |
-| `pnpm lint`          | Lint every workspace                              |
-| `pnpm typecheck`     | Type-check every workspace                        |
-| `pnpm check`         | Run the same core quality gate used before a push |
-| `pnpm expo:doctor`   | Check Expo dependencies and project health        |
-| `pnpm export:web`    | Produce a static web export                       |
-| `pnpm clean`         | Remove generated caches, builds, and coverage     |
+| Command                | What it does                                      |
+| ---------------------- | ------------------------------------------------- |
+| `pnpm dev`             | Start Metro for the development client            |
+| `pnpm ios`             | Build and run the iOS app                         |
+| `pnpm android`         | Build and run the Android app                     |
+| `pnpm web`             | Start the web app                                 |
+| `pnpm test`            | Run every Jest suite                              |
+| `pnpm test:watch`      | Watch the app Jest suite                          |
+| `pnpm test:coverage`   | Write coverage reports for every workspace        |
+| `pnpm generate`        | Generate a shared package                         |
+| `pnpm lint`            | Lint every workspace                              |
+| `pnpm typecheck`       | Type-check every workspace                        |
+| `pnpm check`           | Run the same core quality gate used before a push |
+| `pnpm expo:doctor`     | Check Expo dependencies and project health        |
+| `pnpm check:workflows` | Validate EAS YAML against Expo's live schema      |
+| `pnpm verify:template` | Exercise a clean, renamed template copy           |
+| `pnpm export:web`      | Produce a static web export                       |
+| `pnpm clean`           | Remove generated caches, builds, and coverage     |
 
 Run commands from the repository root. Node and pnpm versions are pinned in `.nvmrc` and
 `package.json`; with Corepack installed, `corepack enable && corepack install` selects the right
@@ -137,18 +141,30 @@ Tests live beside the code they exercise as `*.test.ts` or `*.test.tsx`:
 - theme and utils run in a Node environment with `ts-jest`
 - UI and app tests use `jest-expo` and React Native Testing Library
 - CI keeps package tests and app tests separate, so failures are easy to place
+- CI enforces coverage thresholds and exercises a freshly renamed template through native prebuild
+- native-impacting pull requests compile Android and iOS projects, not just JavaScript
 
 Prefer behavior and accessibility assertions over snapshots. If you change Expo dependencies or
 configuration, run both `pnpm expo:doctor` and `pnpm export:web` before opening a pull request.
 
 ## Make it yours
 
-The starter is deliberately missing authentication, an API client, state management, analytics,
-and a folder full of pretend product code. Add those when your app asks for them.
+The starter is deliberately missing authentication, an API client, state management, an analytics
+vendor, and a folder full of pretend product code. Add those when your app asks for them. The root
+error boundary reports through a small app-owned adapter so the eventual observability vendor does
+not leak into shared packages.
 
 Non-secret Expo values live in `apps/mobile-app/app.config.ts` with local fallbacks. Copy
 `.env.example` to `.env` when you need overrides, and add `EAS_PROJECT_ID` only after creating an EAS
 project.
+
+Before shipping, configure the EAS environments and release workflows described in
+[docs/releasing.md](docs/releasing.md). Production config refuses placeholder native identifiers or
+a missing EAS project ID. The workflows stay manual until a generated app is deliberately linked.
+
+This repository is versioned independently from generated apps. GitHub templates are one-time
+copies, so use [`CHANGELOG.md`](CHANGELOG.md) and [docs/upgrading.md](docs/upgrading.md) to carry
+future starter improvements into existing projects intentionally.
 
 Want package versions and changelogs? Changesets is not installed by default, but
 [docs/adding-changesets.md](docs/adding-changesets.md) walks through the private-package and npm

--- a/apps/mobile-app/.eas/workflows/e2e.yml
+++ b/apps/mobile-app/.eas/workflows/e2e.yml
@@ -1,0 +1,50 @@
+name: Native smoke tests
+
+on:
+  workflow_dispatch: {}
+
+defaults:
+  image: sdk-57
+
+jobs:
+  build_android:
+    name: Build Android test app
+    type: build
+    environment: preview
+    params:
+      platform: android
+      profile: e2e
+
+  test_android:
+    name: Test Android smoke path
+    needs: [build_android]
+    type: maestro
+    environment: preview
+    env:
+      MAESTRO_APP_ID: ${{ env.ANDROID_PACKAGE }}
+    params:
+      build_id: ${{ needs.build_android.outputs.build_id }}
+      flow_path: .maestro/smoke.yml
+      record_screen: true
+      retries: 1
+
+  build_ios:
+    name: Build iOS test app
+    type: build
+    environment: preview
+    params:
+      platform: ios
+      profile: e2e
+
+  test_ios:
+    name: Test iOS smoke path
+    needs: [build_ios]
+    type: maestro
+    environment: preview
+    env:
+      MAESTRO_APP_ID: ${{ env.IOS_BUNDLE_IDENTIFIER }}
+    params:
+      build_id: ${{ needs.build_ios.outputs.build_id }}
+      flow_path: .maestro/smoke.yml
+      record_screen: true
+      retries: 1

--- a/apps/mobile-app/.eas/workflows/production.yml
+++ b/apps/mobile-app/.eas/workflows/production.yml
@@ -1,0 +1,102 @@
+name: Production release
+
+on:
+  workflow_dispatch: {}
+
+defaults:
+  image: sdk-57
+
+jobs:
+  fingerprint:
+    name: Calculate native fingerprints
+    type: fingerprint
+    environment: production
+    env:
+      APP_ENV: production
+
+  get_android_build:
+    name: Find compatible Android build
+    needs: [fingerprint]
+    type: get-build
+    environment: production
+    params:
+      fingerprint_hash: ${{ needs.fingerprint.outputs.android_fingerprint_hash }}
+      platform: android
+      profile: production
+
+  get_ios_build:
+    name: Find compatible iOS build
+    needs: [fingerprint]
+    type: get-build
+    environment: production
+    params:
+      fingerprint_hash: ${{ needs.fingerprint.outputs.ios_fingerprint_hash }}
+      platform: ios
+      profile: production
+
+  approve_release:
+    name: Approve production delivery
+    after: [get_android_build, get_ios_build]
+    type: require-approval
+
+  build_android:
+    name: Build Android binary
+    needs: [get_android_build, approve_release]
+    if: ${{ !needs.get_android_build.outputs.build_id }}
+    type: build
+    environment: production
+    params:
+      platform: android
+      profile: production
+
+  build_ios:
+    name: Build iOS binary
+    needs: [get_ios_build, approve_release]
+    if: ${{ !needs.get_ios_build.outputs.build_id }}
+    type: build
+    environment: production
+    params:
+      platform: ios
+      profile: production
+
+  submit_android:
+    name: Submit Android binary
+    needs: [build_android]
+    type: submit
+    environment: production
+    params:
+      build_id: ${{ needs.build_android.outputs.build_id }}
+      profile: production
+
+  submit_ios:
+    name: Submit iOS binary
+    needs: [build_ios]
+    type: submit
+    environment: production
+    params:
+      build_id: ${{ needs.build_ios.outputs.build_id }}
+      profile: production
+
+  update_android:
+    name: Publish Android update
+    needs: [get_android_build, approve_release]
+    if: ${{ needs.get_android_build.outputs.build_id }}
+    type: update
+    environment: production
+    env:
+      APP_ENV: production
+    params:
+      branch: production
+      platform: android
+
+  update_ios:
+    name: Publish iOS update
+    needs: [get_ios_build, approve_release]
+    if: ${{ needs.get_ios_build.outputs.build_id }}
+    type: update
+    environment: production
+    env:
+      APP_ENV: production
+    params:
+      branch: production
+      platform: ios

--- a/apps/mobile-app/.maestro/smoke.yml
+++ b/apps/mobile-app/.maestro/smoke.yml
@@ -1,0 +1,8 @@
+appId: ${MAESTRO_APP_ID}
+---
+- launchApp:
+    clearState: true
+- assertVisible: 'Expo Turbo Starter'
+- assertVisible: 'Tiny proof: 0/10'
+- tapOn: 'Add one'
+- assertVisible: 'Tiny proof: 1/10'

--- a/apps/mobile-app/app.config.ts
+++ b/apps/mobile-app/app.config.ts
@@ -1,11 +1,57 @@
 import type { ExpoConfig } from 'expo/config';
 
-const appName = process.env.APP_NAME ?? 'Expo Turbo Starter';
-const appSlug = process.env.APP_SLUG ?? 'expo-turbo-starter';
-const appScheme = process.env.APP_SCHEME ?? 'expo-turbo-starter';
-const iosBundleIdentifier = process.env.IOS_BUNDLE_IDENTIFIER ?? 'com.example.expoturbostarter';
-const androidPackage = process.env.ANDROID_PACKAGE ?? 'com.example.expoturbostarter';
-const easProjectId = process.env.EAS_PROJECT_ID;
+export type AppIdentity = {
+  androidPackage: string;
+  appName: string;
+  appScheme: string;
+  appSlug: string;
+  easProjectId: string | undefined;
+  iosBundleIdentifier: string;
+};
+
+type Environment = Readonly<Record<string, string | undefined>>;
+
+const defaults: AppIdentity = {
+  androidPackage: 'com.example.expoturbostarter',
+  appName: 'Expo Turbo Starter',
+  appScheme: 'expo-turbo-starter',
+  appSlug: 'expo-turbo-starter',
+  easProjectId: undefined,
+  iosBundleIdentifier: 'com.example.expoturbostarter',
+};
+
+export function resolveAppIdentity(environment: Environment): AppIdentity {
+  const identity = {
+    androidPackage: environment.ANDROID_PACKAGE ?? defaults.androidPackage,
+    appName: environment.APP_NAME ?? defaults.appName,
+    appScheme: environment.APP_SCHEME ?? defaults.appScheme,
+    appSlug: environment.APP_SLUG ?? defaults.appSlug,
+    easProjectId: environment.EAS_PROJECT_ID,
+    iosBundleIdentifier: environment.IOS_BUNDLE_IDENTIFIER ?? defaults.iosBundleIdentifier,
+  };
+
+  const isProductionBuild =
+    environment.APP_ENV === 'production' || environment.EAS_BUILD_PROFILE === 'production';
+
+  if (isProductionBuild && identity.iosBundleIdentifier.startsWith('com.example.')) {
+    throw new Error('Production builds require a non-placeholder IOS_BUNDLE_IDENTIFIER.');
+  }
+
+  if (isProductionBuild && identity.androidPackage.startsWith('com.example.')) {
+    throw new Error('Production builds require a non-placeholder ANDROID_PACKAGE.');
+  }
+
+  if (isProductionBuild && !identity.easProjectId) {
+    throw new Error(
+      'Production builds require EAS_PROJECT_ID. Run eas init and configure it first.'
+    );
+  }
+
+  return identity;
+}
+
+const { androidPackage, appName, appScheme, appSlug, easProjectId, iosBundleIdentifier } =
+  resolveAppIdentity(process.env);
 
 const config: ExpoConfig = {
   name: appName,
@@ -15,7 +61,6 @@ const config: ExpoConfig = {
   icon: './assets/images/icon.png',
   scheme: appScheme,
   userInterfaceStyle: 'automatic',
-  newArchEnabled: true,
   ios: {
     bundleIdentifier: iosBundleIdentifier,
     icon: './assets/expo.icon',
@@ -50,6 +95,14 @@ const config: ExpoConfig = {
     reactCompiler: true,
     typedRoutes: true,
   },
+  runtimeVersion: {
+    policy: 'fingerprint',
+  },
+  updates: easProjectId
+    ? {
+        url: `https://u.expo.dev/${easProjectId}`,
+      }
+    : undefined,
   extra: easProjectId
     ? {
         eas: {

--- a/apps/mobile-app/config/app-identity.test.ts
+++ b/apps/mobile-app/config/app-identity.test.ts
@@ -1,0 +1,56 @@
+import { resolveAppIdentity } from '../app.config';
+
+describe('resolveAppIdentity', () => {
+  it('refuses to resolve a production build with placeholder native identifiers', () => {
+    expect(() =>
+      resolveAppIdentity({
+        ANDROID_PACKAGE: 'com.acme.mobile',
+        EAS_BUILD_PROFILE: 'production',
+        EAS_PROJECT_ID: '00000000-0000-0000-0000-000000000000',
+        IOS_BUNDLE_IDENTIFIER: 'com.example.mobile',
+      })
+    ).toThrow('Production builds require a non-placeholder IOS_BUNDLE_IDENTIFIER');
+  });
+
+  it('checks the Android identifier independently for production builds', () => {
+    expect(() =>
+      resolveAppIdentity({
+        ANDROID_PACKAGE: 'com.example.mobile',
+        EAS_BUILD_PROFILE: 'production',
+        EAS_PROJECT_ID: '00000000-0000-0000-0000-000000000000',
+        IOS_BUNDLE_IDENTIFIER: 'com.acme.mobile',
+      })
+    ).toThrow('Production builds require a non-placeholder ANDROID_PACKAGE');
+  });
+
+  it('requires an EAS project before resolving production configuration', () => {
+    expect(() =>
+      resolveAppIdentity({
+        ANDROID_PACKAGE: 'com.acme.mobile',
+        APP_ENV: 'production',
+        IOS_BUNDLE_IDENTIFIER: 'com.acme.mobile',
+      })
+    ).toThrow('Production builds require EAS_PROJECT_ID');
+  });
+
+  it('resolves a fully configured production identity', () => {
+    expect(
+      resolveAppIdentity({
+        ANDROID_PACKAGE: 'com.acme.mobile',
+        APP_NAME: 'Acme Mobile',
+        APP_SCHEME: 'acme-mobile',
+        APP_SLUG: 'acme-mobile',
+        EAS_BUILD_PROFILE: 'production',
+        EAS_PROJECT_ID: '00000000-0000-0000-0000-000000000000',
+        IOS_BUNDLE_IDENTIFIER: 'com.acme.mobile',
+      })
+    ).toEqual({
+      androidPackage: 'com.acme.mobile',
+      appName: 'Acme Mobile',
+      appScheme: 'acme-mobile',
+      appSlug: 'acme-mobile',
+      easProjectId: '00000000-0000-0000-0000-000000000000',
+      iosBundleIdentifier: 'com.acme.mobile',
+    });
+  });
+});

--- a/apps/mobile-app/eas.json
+++ b/apps/mobile-app/eas.json
@@ -1,18 +1,46 @@
 {
   "cli": {
-    "version": ">= 16.0.0",
+    "version": ">= 21.0.2 < 22.0.0",
     "appVersionSource": "remote"
   },
   "build": {
     "development": {
       "developmentClient": true,
-      "distribution": "internal"
+      "distribution": "internal",
+      "environment": "development",
+      "env": {
+        "APP_ENV": "development"
+      },
+      "channel": "development"
     },
     "preview": {
-      "distribution": "internal"
+      "distribution": "internal",
+      "environment": "preview",
+      "env": {
+        "APP_ENV": "preview"
+      },
+      "channel": "preview"
+    },
+    "e2e": {
+      "extends": "preview",
+      "withoutCredentials": true,
+      "ios": {
+        "simulator": true
+      },
+      "android": {
+        "buildType": "apk"
+      }
     },
     "production": {
-      "autoIncrement": true
+      "autoIncrement": true,
+      "environment": "production",
+      "env": {
+        "APP_ENV": "production"
+      },
+      "channel": "production"
     }
+  },
+  "submit": {
+    "production": {}
   }
 }

--- a/apps/mobile-app/package.json
+++ b/apps/mobile-app/package.json
@@ -30,6 +30,7 @@
     "expo-splash-screen": "~57.0.4",
     "expo-status-bar": "~57.0.1",
     "expo-system-ui": "~57.0.1",
+    "expo-updates": "~57.0.8",
     "react": "19.2.3",
     "react-dom": "19.2.3",
     "react-native": "0.86.0",

--- a/apps/mobile-app/src/app/_layout.tsx
+++ b/apps/mobile-app/src/app/_layout.tsx
@@ -1,5 +1,11 @@
-import { Stack } from 'expo-router';
+import { Stack, type ErrorBoundaryProps } from 'expo-router';
 import { StatusBar } from 'expo-status-bar';
+
+import { RootErrorScreen } from '@/screens/root-error';
+
+export function ErrorBoundary(props: ErrorBoundaryProps) {
+  return <RootErrorScreen {...props} />;
+}
 
 export default function RootLayout() {
   return (

--- a/apps/mobile-app/src/observability/error-reporter.ts
+++ b/apps/mobile-app/src/observability/error-reporter.ts
@@ -1,0 +1,25 @@
+export type ErrorReportContext = Readonly<{
+  source: string;
+}>;
+
+export type ErrorReporter = (error: Error, context: ErrorReportContext) => void;
+
+const noopReporter: ErrorReporter = () => undefined;
+let activeReporter = noopReporter;
+
+export function configureErrorReporter(reporter: ErrorReporter) {
+  const previousReporter = activeReporter;
+  activeReporter = reporter;
+
+  return () => {
+    activeReporter = previousReporter;
+  };
+}
+
+export function reportError(error: Error, context: ErrorReportContext) {
+  try {
+    activeReporter(error, context);
+  } catch {
+    // Error reporting must never turn a recoverable render failure into another app failure.
+  }
+}

--- a/apps/mobile-app/src/screens/root-error/index.ts
+++ b/apps/mobile-app/src/screens/root-error/index.ts
@@ -1,0 +1,1 @@
+export { RootErrorScreen, type RootErrorScreenProps } from './root-error-screen';

--- a/apps/mobile-app/src/screens/root-error/root-error-screen.test.tsx
+++ b/apps/mobile-app/src/screens/root-error/root-error-screen.test.tsx
@@ -1,0 +1,49 @@
+import { fireEvent, render, screen } from '@testing-library/react-native';
+
+import { configureErrorReporter } from '@/observability/error-reporter';
+
+import { RootErrorScreen } from './root-error-screen';
+
+describe('RootErrorScreen', () => {
+  it('offers a safe recovery path without exposing the underlying error', async () => {
+    const retry = jest.fn();
+
+    await render(<RootErrorScreen error={new Error('secret request payload')} retry={retry} />);
+
+    expect(screen.getByText('Something went wrong')).toBeOnTheScreen();
+    expect(screen.queryByText('secret request payload')).not.toBeOnTheScreen();
+
+    fireEvent.press(screen.getByRole('button', { name: 'Try again' }));
+
+    expect(retry).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports the root failure through the app-owned observability seam', async () => {
+    const reporter = jest.fn();
+    const restoreReporter = configureErrorReporter(reporter);
+
+    try {
+      const error = new Error('render failed');
+
+      await render(<RootErrorScreen error={error} retry={jest.fn()} />);
+
+      expect(reporter).toHaveBeenCalledWith(error, { source: 'root-error-boundary' });
+    } finally {
+      restoreReporter();
+    }
+  });
+
+  it('keeps the recovery screen usable when the configured reporter fails', async () => {
+    const restoreReporter = configureErrorReporter(() => {
+      throw new Error('reporting unavailable');
+    });
+
+    try {
+      await render(<RootErrorScreen error={new Error('render failed')} retry={jest.fn()} />);
+
+      expect(screen.getByRole('button', { name: 'Try again' })).toBeOnTheScreen();
+    } finally {
+      restoreReporter();
+    }
+  });
+});

--- a/apps/mobile-app/src/screens/root-error/root-error-screen.tsx
+++ b/apps/mobile-app/src/screens/root-error/root-error-screen.tsx
@@ -1,0 +1,32 @@
+import { useEffect } from 'react';
+import { View } from 'react-native';
+import { useUnistyles } from 'react-native-unistyles';
+
+import { Button, Screen, Text } from '@starter/ui';
+
+import { reportError } from '@/observability/error-reporter';
+
+export type RootErrorScreenProps = {
+  error: Error;
+  retry: () => void;
+};
+
+export function RootErrorScreen({ error, retry }: RootErrorScreenProps) {
+  const { theme } = useUnistyles();
+
+  useEffect(() => {
+    reportError(error, { source: 'root-error-boundary' });
+  }, [error]);
+
+  return (
+    <Screen contentContainerStyle={{ justifyContent: 'center' }}>
+      <View accessibilityRole="alert" style={{ gap: theme.space.sm }}>
+        <Text variant="heading">Something went wrong</Text>
+        <Text style={{ color: theme.colors.mutedText }}>
+          The app hit an unexpected problem. Try again to reload this screen.
+        </Text>
+      </View>
+      <Button label="Try again" onPress={retry} />
+    </Screen>
+  );
+}

--- a/apps/mobile-app/tsconfig.json
+++ b/apps/mobile-app/tsconfig.json
@@ -8,5 +8,12 @@
       "@/assets/*": ["./assets/*"]
     }
   },
-  "include": ["src/**/*.ts", "src/**/*.tsx", ".expo/types/**/*.ts", "expo-env.d.ts"]
+  "include": [
+    "src/**/*.ts",
+    "src/**/*.tsx",
+    "config/**/*.ts",
+    "app.config.ts",
+    ".expo/types/**/*.ts",
+    "expo-env.d.ts"
+  ]
 }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -19,6 +19,11 @@ Router files under `src/app` only connect a URL to a screen; the screen body bel
 The app is also the right home for choices that are not universal: authentication, API clients,
 state management, analytics, feature flags, and error reporting.
 
+The root Expo Router error boundary renders an app-owned recovery screen and reports through
+`src/observability/error-reporter.ts`. Its default implementation is deliberately a no-op. Configure
+that adapter when the product selects an observability vendor; keep vendor SDKs out of shared UI and
+avoid exposing raw error messages to users.
+
 ## Packages have one job
 
 `@starter/theme` contains semantic design tokens and the typed light and dark themes. It has no React
@@ -68,3 +73,5 @@ For another app, keep its routes and theme registration app-owned. Add app-speci
 Jest, and EAS configuration rather than teaching shared packages about a particular consumer.
 
 Then run `pnpm install`, `pnpm check`, and—for app or dependency changes—`pnpm expo:doctor`.
+Production app configuration also requires real native identifiers and an EAS project ID; the config
+fails closed instead of allowing a placeholder build to ship.

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,0 +1,71 @@
+# Production Releases
+
+The starter ships production-safe release plumbing without linking itself to an Expo account or app
+store. The EAS workflows are manual until a generated application is configured, so creating a repo
+from this template cannot accidentally spend build minutes or publish an update.
+
+## Link the generated app
+
+Run `pnpm run setup` first and commit `.template-initialized.json`. Then, from
+`apps/mobile-app`, link the app to an EAS project using the pinned major accepted by `eas.json`:
+
+```sh
+pnpm dlx eas-cli@21.0.2 init
+```
+
+Keep `EAS_PROJECT_ID` in local and EAS environment configuration. The project ID is not secret, but
+using the same variable locally and remotely prevents the resolved config from drifting. Configure
+the following values in the `development`, `preview`, and `production` EAS environments:
+
+- `APP_NAME`
+- `APP_SLUG`
+- `APP_SCHEME`
+- `IOS_BUNDLE_IDENTIFIER`
+- `ANDROID_PACKAGE`
+- `EAS_PROJECT_ID`
+
+The build profiles set `APP_ENV`. Production config intentionally fails when it sees placeholder
+native identifiers or a missing project ID.
+
+Initialize signing credentials with one deliberate build per platform before relying on automation.
+App stores may also require the first Android submission to be uploaded manually.
+
+## Validate a release candidate
+
+The native smoke workflow builds installable Android and iOS artifacts, then runs the same stable
+Maestro flow on both:
+
+```sh
+cd apps/mobile-app
+pnpm dlx eas-cli@21.0.2 workflow:run .eas/workflows/e2e.yml
+```
+
+For a local installed build, run:
+
+```sh
+MAESTRO_APP_ID=com.example.yourapp maestro test .maestro/smoke.yml
+```
+
+Keep the default smoke flow fast and unauthenticated. Product-specific journeys belong in additional
+flows with their own test-data strategy.
+
+## Deliver production
+
+Update the user-facing `version` in `app.config.ts`, merge only after GitHub CI and smoke validation
+pass, then dispatch:
+
+```sh
+cd apps/mobile-app
+pnpm dlx eas-cli@21.0.2 workflow:run .eas/workflows/production.yml
+```
+
+The workflow calculates each platform's native fingerprint and pauses for approval. If no compatible
+binary exists, it builds and submits one. If a compatible binary exists, it publishes an OTA update
+to the production branch. Build numbers remain EAS-managed through `appVersionSource: remote` and
+`autoIncrement`.
+
+Never add dates, commit hashes, or other volatile values to fingerprinted native configuration. A
+fingerprint must describe compatibility, not a particular CI attempt.
+
+For a bad OTA, republish the last known-good update. For a bad binary, create and submit a new binary;
+store releases cannot be rolled back by an OTA.

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -1,0 +1,34 @@
+# Maintaining and Upgrading the Starter
+
+GitHub creates a template consumer with a new, unrelated history. Updating this repository improves
+future projects; it does not silently modify applications already created from it.
+
+## Version contract
+
+- The root `package.json` version is the template version.
+- `pnpm run setup` records that version in `.template-initialized.json`.
+- Every template release updates `CHANGELOG.md` with adoption notes.
+- Stable releases receive a `v<version>` Git tag and GitHub release.
+- `main` is the supported moving target; security fixes are not backported to old template versions.
+
+Existing applications should compare their recorded version with the changelog, then port relevant
+changes as normal application pull requests. Prefer copying small commits or files deliberately over
+merging histories that GitHub created as unrelated.
+
+If multiple applications need to receive the same runtime behavior continuously, that behavior has
+outgrown the template. Move it into a versioned package or a maintained generator migration instead
+of copying it repeatedly.
+
+## Expo upgrade loop
+
+For every Expo SDK upgrade:
+
+1. Create a dedicated branch and update Expo-managed dependencies with `expo install`.
+2. Update duplicated React Native test dependencies in shared native packages.
+3. Run `pnpm install --frozen-lockfile`, `pnpm check`, `pnpm expo:doctor`,
+   `pnpm check:workflows`, and `pnpm verify:template`.
+4. Run both platforms through `.eas/workflows/e2e.yml` before tagging the template release.
+5. Record native rebuild requirements and downstream migration notes in `CHANGELOG.md`.
+
+Dependabot is an input to this loop, not an automatic compatibility decision. Expo, React, React
+Native, Jest, TypeScript, and native modules should move as a tested compatibility set.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -33,5 +33,41 @@ export default defineConfig([
       globals: globals.node,
     },
   },
+  {
+    files: ['packages/**/*.{ts,tsx}'],
+    rules: {
+      'no-restricted-imports': [
+        'error',
+        {
+          patterns: [
+            {
+              group: ['@starter/*/*'],
+              message: 'Import another workspace package through its public entrypoint.',
+            },
+            {
+              group: ['@/**', '**/apps/**'],
+              message: 'Shared packages must not import application source.',
+            },
+          ],
+        },
+      ],
+    },
+  },
+  {
+    files: ['apps/**/*.{ts,tsx}'],
+    rules: {
+      'no-restricted-imports': [
+        'error',
+        {
+          patterns: [
+            {
+              group: ['@starter/*/*'],
+              message: 'Import workspace packages through their public entrypoints.',
+            },
+          ],
+        },
+      ],
+    },
+  },
   eslintConfigPrettier,
 ]);

--- a/package.json
+++ b/package.json
@@ -1,7 +1,11 @@
 {
   "name": "expo-turbo-starter",
-  "version": "0.0.0",
+  "version": "1.0.0",
   "private": true,
+  "engines": {
+    "node": ">=24 <25",
+    "pnpm": "10.11.1"
+  },
   "scripts": {
     "dev": "pnpm --filter @starter/mobile-app dev",
     "ios": "pnpm --filter @starter/mobile-app ios",
@@ -26,14 +30,18 @@
     "clean": "node scripts/clean.mjs",
     "expo:doctor": "pnpm --filter @starter/mobile-app exec expo-doctor",
     "expo:config": "pnpm --filter @starter/mobile-app exec expo config --type public",
+    "check:workflows": "node scripts/validate-eas-workflows.mjs apps/mobile-app/.eas/workflows/production.yml apps/mobile-app/.eas/workflows/e2e.yml",
+    "verify:template": "node scripts/verify-template.mjs",
     "check": "pnpm format:check && pnpm build:packages && pnpm lint && pnpm typecheck && pnpm test && pnpm expo:config",
     "setup": "node scripts/initialize-template.mjs",
     "generate": "node scripts/generate.mjs"
   },
   "devDependencies": {
-    "@types/jest": "29.5.14",
     "@jest/transform": "29.7.0",
     "@jest/types": "29.6.3",
+    "@types/jest": "29.5.14",
+    "ajv": "8.18.0",
+    "ajv-formats": "3.0.1",
     "babel-jest": "29.7.0",
     "eslint": "9.39.5",
     "eslint-config-expo": "57.0.0",
@@ -42,6 +50,7 @@
     "globals": "17.7.0",
     "jest": "29.7.0",
     "jest-util": "29.7.0",
+    "js-yaml": "4.2.0",
     "prettier": "3.9.5",
     "ts-jest": "29.4.11",
     "turbo": "2.10.5",
@@ -53,6 +62,7 @@
       "unrs-resolver"
     ],
     "overrides": {
+      "js-yaml@4.1.0": "4.2.0",
       "xcode>uuid": "11.1.1"
     }
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,6 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
+  js-yaml@4.1.0: 4.2.0
   xcode>uuid: 11.1.1
 
 importers:
@@ -20,6 +21,12 @@ importers:
       '@types/jest':
         specifier: 29.5.14
         version: 29.5.14
+      ajv:
+        specifier: 8.18.0
+        version: 8.18.0
+      ajv-formats:
+        specifier: 3.0.1
+        version: 3.0.1(ajv@8.18.0)
       babel-jest:
         specifier: 29.7.0
         version: 29.7.0(@babel/core@7.29.7)
@@ -40,16 +47,19 @@ importers:
         version: 17.7.0
       jest:
         specifier: 29.7.0
-        version: 29.7.0(@types/node@26.1.1)
+        version: 29.7.0(@types/node@26.1.1)(ts-node@10.9.2(@types/node@26.1.1)(typescript@6.0.3))
       jest-util:
         specifier: 29.7.0
         version: 29.7.0
+      js-yaml:
+        specifier: 4.2.0
+        version: 4.2.0
       prettier:
         specifier: 3.9.5
         version: 3.9.5
       ts-jest:
         specifier: 29.4.11
-        version: 29.4.11(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.7))(jest-util@29.7.0)(jest@29.7.0(@types/node@26.1.1))(typescript@6.0.3)
+        version: 29.4.11(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.7))(jest-util@29.7.0)(jest@29.7.0(@types/node@26.1.1)(ts-node@10.9.2(@types/node@26.1.1)(typescript@6.0.3)))(typescript@6.0.3)
       turbo:
         specifier: 2.10.5
         version: 2.10.5
@@ -85,7 +95,7 @@ importers:
         version: 57.0.3(expo@57.0.7)(react-native@0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3))(react@19.2.3)
       expo-router:
         specifier: ~57.0.7
-        version: 57.0.7(1743bdfbd8e1512c8e24536b8defc5c8)
+        version: 57.0.7(0b23e7d965b558fa330d3fabed921333)
       expo-splash-screen:
         specifier: ~57.0.4
         version: 57.0.4(expo@57.0.7)(typescript@6.0.3)
@@ -95,6 +105,9 @@ importers:
       expo-system-ui:
         specifier: ~57.0.1
         version: 57.0.1(expo@57.0.7)(react-native-web@0.21.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-native@0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3))
+      expo-updates:
+        specifier: ~57.0.8
+        version: 57.0.8(expo-dev-client@57.0.7(expo@57.0.7)(react-native@0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3)))(expo@57.0.7)(react-native@0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3))(react@19.2.3)
       react:
         specifier: 19.2.3
         version: 19.2.3
@@ -134,7 +147,7 @@ importers:
     devDependencies:
       '@testing-library/react-native':
         specifier: 14.0.1
-        version: 14.0.1(jest@29.7.0(@types/node@26.1.1))(react-native@0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3))(react@19.2.3)(test-renderer@1.2.0(@types/react@19.2.17)(react@19.2.3))
+        version: 14.0.1(jest@29.7.0(@types/node@26.1.1)(ts-node@10.9.2(@types/node@26.1.1)(typescript@6.0.3)))(react-native@0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3))(react@19.2.3)(test-renderer@1.2.0(@types/react@19.2.17)(react@19.2.3))
       '@types/react':
         specifier: ~19.2.2
         version: 19.2.17
@@ -143,10 +156,10 @@ importers:
         version: 1.20.1
       jest:
         specifier: 29.7.0
-        version: 29.7.0(@types/node@26.1.1)
+        version: 29.7.0(@types/node@26.1.1)(ts-node@10.9.2(@types/node@26.1.1)(typescript@6.0.3))
       jest-expo:
         specifier: 57.0.2
-        version: 57.0.2(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(expo@57.0.7)(jest@29.7.0(@types/node@26.1.1))(react-native@0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3))(react@19.2.3)
+        version: 57.0.2(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(expo@57.0.7)(jest@29.7.0(@types/node@26.1.1)(ts-node@10.9.2(@types/node@26.1.1)(typescript@6.0.3)))(react-native@0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3))(react@19.2.3)
       test-renderer:
         specifier: 1.2.0
         version: 1.2.0(@types/react@19.2.17)(react@19.2.3)
@@ -164,7 +177,7 @@ importers:
     devDependencies:
       '@testing-library/react-native':
         specifier: 14.0.1
-        version: 14.0.1(jest@29.7.0(@types/node@26.1.1))(react-native@0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3))(react@19.2.3)(test-renderer@1.2.0(@types/react@19.2.17)(react@19.2.3))
+        version: 14.0.1(jest@29.7.0(@types/node@26.1.1)(ts-node@10.9.2(@types/node@26.1.1)(typescript@6.0.3)))(react-native@0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3))(react@19.2.3)(test-renderer@1.2.0(@types/react@19.2.17)(react@19.2.3))
       '@types/react':
         specifier: ~19.2.2
         version: 19.2.17
@@ -173,10 +186,10 @@ importers:
         version: 57.0.7(@babel/core@7.29.7)(@expo/dom-webview@57.0.1)(@expo/metro-runtime@57.0.6)(expo-router@57.0.7)(react-dom@19.2.3(react@19.2.3))(react-native-web@0.21.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-native-worklets@0.10.0(@babel/core@7.29.7)(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(react-native@0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3))(react@19.2.3))(react-native@0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3))(react@19.2.3)(typescript@6.0.3)
       jest:
         specifier: 29.7.0
-        version: 29.7.0(@types/node@26.1.1)
+        version: 29.7.0(@types/node@26.1.1)(ts-node@10.9.2(@types/node@26.1.1)(typescript@6.0.3))
       jest-expo:
         specifier: 57.0.2
-        version: 57.0.2(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(expo@57.0.7)(jest@29.7.0(@types/node@26.1.1))(react-native@0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3))(react@19.2.3)
+        version: 57.0.2(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(expo@57.0.7)(jest@29.7.0(@types/node@26.1.1)(ts-node@10.9.2(@types/node@26.1.1)(typescript@6.0.3)))(react-native@0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3))(react@19.2.3)
       react:
         specifier: 19.2.3
         version: 19.2.3
@@ -664,6 +677,10 @@ packages:
   '@bcoe/v8-coverage@0.2.3':
     resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
 
+  '@cspotcode/source-map-support@0.8.1':
+    resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
+    engines: {node: '>=12'}
+
   '@egjs/hammerjs@2.0.17':
     resolution: {integrity: sha512-XQsZgjm2EcVUiZQf11UBJQfmZeEmOW8DpI1gsFeln6w0ae0ii4dMQEQ0kjl6DspdWX1aGY1/loyXnP0JS06e/A==}
     engines: {node: '>=0.8.0'}
@@ -1036,6 +1053,9 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
+  '@jridgewell/trace-mapping@0.3.9':
+    resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
+
   '@napi-rs/wasm-runtime@1.1.6':
     resolution: {integrity: sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==}
     peerDependencies:
@@ -1401,6 +1421,18 @@ packages:
     resolution: {integrity: sha512-HqmEUIGRJ5fSXchkVgR5F7qn48bDBzv0kWj/Kfu5e6uci4UlEeng4331LnBkWffb++Ei3FOVLxo8JJWMFBDMeQ==}
     engines: {node: '>= 10'}
 
+  '@tsconfig/node10@1.0.12':
+    resolution: {integrity: sha512-UCYBaeFvM11aU2y3YPZ//O5Rhj+xKyzy7mvcIoAjASbigy8mHMryP5cK7dgjlz2hWxh1g5pLw084E0a/wlUSFQ==}
+
+  '@tsconfig/node12@1.0.11':
+    resolution: {integrity: sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==}
+
+  '@tsconfig/node14@1.0.3':
+    resolution: {integrity: sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==}
+
+  '@tsconfig/node16@1.0.4':
+    resolution: {integrity: sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==}
+
   '@turbo/darwin-64@2.10.5':
     resolution: {integrity: sha512-ENvPwy3x5yS7MwNYHeWjqOBXkwIMp39Pd+/zXC6PoiNzF8EIvvLZOZZ+ny6L9x4WgS5vxUii2LM5gM+zjPdnWw==}
     cpu: [x64]
@@ -1731,8 +1763,19 @@ packages:
     engines: {node: '>=18.18'}
     hasBin: true
 
+  ajv-formats@3.0.1:
+    resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
+    peerDependencies:
+      ajv: ^8.0.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
+
   ajv@6.15.0:
     resolution: {integrity: sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==}
+
+  ajv@8.18.0:
+    resolution: {integrity: sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==}
 
   anser@1.4.10:
     resolution: {integrity: sha512-hCv9AqTQ8ycjpSd3upOJd7vFwW1JaoYQ7tpham03GJ1ca8/65rqn0RpaWpItOAd6ylW9wAw6luXYPJIyPFVOww==}
@@ -1772,6 +1815,9 @@ packages:
   anymatch@3.1.3:
     resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
     engines: {node: '>= 8'}
+
+  arg@4.1.3:
+    resolution: {integrity: sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==}
 
   arg@5.0.2:
     resolution: {integrity: sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==}
@@ -2121,6 +2167,9 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     hasBin: true
 
+  create-require@1.1.1:
+    resolution: {integrity: sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==}
+
   cross-fetch@3.2.0:
     resolution: {integrity: sha512-Q+xVJLoGOeIMXZmbUK4HYk+69cQH6LudR0Vu/pRm2YlU/hDV9CiS0gKUMaWY5f2NeUH9C1nV3bsTlCo0FsTV1Q==}
 
@@ -2251,6 +2300,10 @@ packages:
   diff-sequences@29.6.3:
     resolution: {integrity: sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  diff@4.0.4:
+    resolution: {integrity: sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==}
+    engines: {node: '>=0.3.1'}
 
   dnssd-advertise@1.1.6:
     resolution: {integrity: sha512-Ndrrf6BMPalkQPd/zubL+4YghH2J9NspapQ09uDXwYbvOPkP0oaqf5CkcwJ0b50kS2O3ul6yVu+jz+RY62Cejg==}
@@ -2562,6 +2615,9 @@ packages:
     engines: {node: ^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0}
     hasBin: true
 
+  expo-eas-client@57.0.1:
+    resolution: {integrity: sha512-4w51+zsl/ziUHQMJgLgUdgsNhRPAwHBfySpPB1hpWU21X74QS9T4SqDftaRnrDagn/DfcrXUMJvHbDQUxLPJNA==}
+
   expo-file-system@57.0.1:
     resolution: {integrity: sha512-w7/ERvQFrGP2apTO9lDtZ+O6JQIhfakL7+Xqzh+rfMO9B4LB4qwrz+YvLgir8KFRVX64JHBnRuYBVLY1oQZcqw==}
     peerDependencies:
@@ -2669,6 +2725,9 @@ packages:
       react: '*'
       react-native: '*'
 
+  expo-structured-headers@57.0.0:
+    resolution: {integrity: sha512-//t9UNPbJSEysc2x4VKJG/u7Osvv5DYJWsET5bqt/B+qcD1by/JXvSQzX3Q/YAgA96xFPontrz6OAPLbO4JKEA==}
+
   expo-symbols@57.0.1:
     resolution: {integrity: sha512-8Zf+a83OywV0vf1NUtSKpNqKcULmO0GTI+zfFnGYl7SLDH9FjL5RcEZoy6CHvCgq2KDrQF21pl3r7Tb4ItPscw==}
     peerDependencies:
@@ -2691,6 +2750,18 @@ packages:
     resolution: {integrity: sha512-+LUWwJ0gf/TEKMVdQAw/Gjih4dvrk+URgy24X9qEGKuuMDZqjBRm9T4yQyBVALGL5TTdPUaB6ILxx3lshm3pwQ==}
     peerDependencies:
       expo: '*'
+
+  expo-updates@57.0.8:
+    resolution: {integrity: sha512-vHQYneTGoPZbA/3dtQlfrWQMyRjqO4t0g2K97Z3VX0K8GSTcANzTPe1MDYncGf7cU/nBIShgWXx7qSbLICEVdQ==}
+    hasBin: true
+    peerDependencies:
+      expo: '*'
+      expo-dev-client: '*'
+      react: '*'
+      react-native: '*'
+    peerDependenciesMeta:
+      expo-dev-client:
+        optional: true
 
   expo@57.0.7:
     resolution: {integrity: sha512-PJdE0EjoX878OqClmsigVKdT0jCNOAQDRLcvFkeBakxaVyEDhjcQ8baKq2YysYH2g0YNB1rEIpHUiKtluO918A==}
@@ -2726,6 +2797,9 @@ packages:
 
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
+
+  fast-uri@3.1.4:
+    resolution: {integrity: sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==}
 
   fb-dotslash@0.5.8:
     resolution: {integrity: sha512-XHYLKk9J4BupDxi9bSEhkfss0m+Vr9ChTrjhf9l2iw3jB5C7BnY4GVPoMcqbrTutsKJso6yj2nAB6BI/F2oZaA==}
@@ -3399,6 +3473,10 @@ packages:
     resolution: {integrity: sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==}
     hasBin: true
 
+  js-yaml@4.2.0:
+    resolution: {integrity: sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==}
+    hasBin: true
+
   js-yaml@4.3.0:
     resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
     hasBin: true
@@ -3428,6 +3506,9 @@ packages:
 
   json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
+
+  json-schema-traverse@1.0.0:
+    resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
 
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
@@ -4251,6 +4332,10 @@ packages:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
     engines: {node: '>=0.10.0'}
 
+  require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
+    engines: {node: '>=0.10.0'}
+
   requires-port@1.0.0:
     resolution: {integrity: sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==}
 
@@ -4670,6 +4755,20 @@ packages:
       jest-util:
         optional: true
 
+  ts-node@10.9.2:
+    resolution: {integrity: sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==}
+    hasBin: true
+    peerDependencies:
+      '@swc/core': '>=1.2.50'
+      '@swc/wasm': '>=1.2.50'
+      '@types/node': '*'
+      typescript: '>=2.7'
+    peerDependenciesMeta:
+      '@swc/core':
+        optional: true
+      '@swc/wasm':
+        optional: true
+
   tsconfig-paths@3.15.0:
     resolution: {integrity: sha512-2Ac2RgzDe/cn48GvOe3M+o82pEFewD3UPbyoUHHdKasHwJKjds4fLXWf/Ux5kATBKN20oaFGu+jbElp1pos0mg==}
 
@@ -4808,6 +4907,9 @@ packages:
   uuid@11.1.1:
     resolution: {integrity: sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==}
     hasBin: true
+
+  v8-compile-cache-lib@3.0.1:
+    resolution: {integrity: sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==}
 
   v8-to-istanbul@9.3.0:
     resolution: {integrity: sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==}
@@ -4977,6 +5079,10 @@ packages:
   yargs@17.7.3:
     resolution: {integrity: sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==}
     engines: {node: '>=12'}
+
+  yn@3.1.1:
+    resolution: {integrity: sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==}
+    engines: {node: '>=6'}
 
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
@@ -5554,6 +5660,11 @@ snapshots:
 
   '@bcoe/v8-coverage@0.2.3': {}
 
+  '@cspotcode/source-map-support@0.8.1':
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.9
+    optional: true
+
   '@egjs/hammerjs@2.0.17':
     dependencies:
       '@types/hammerjs': 2.0.46
@@ -5684,7 +5795,7 @@ snapshots:
       ws: 8.21.1
       zod: 3.25.76
     optionalDependencies:
-      expo-router: 57.0.7(1743bdfbd8e1512c8e24536b8defc5c8)
+      expo-router: 57.0.7(0b23e7d965b558fa330d3fabed921333)
       react-native: 0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3)
     transitivePeerDependencies:
       - '@expo/dom-webview'
@@ -5961,7 +6072,7 @@ snapshots:
       react: 19.2.3
     optionalDependencies:
       '@expo/metro-runtime': 57.0.6(@expo/log-box@57.0.1)(expo@57.0.7)(react-dom@19.2.3(react@19.2.3))(react-native@0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3))(react@19.2.3)
-      expo-router: 57.0.7(1743bdfbd8e1512c8e24536b8defc5c8)
+      expo-router: 57.0.7(0b23e7d965b558fa330d3fabed921333)
       react-dom: 19.2.3(react@19.2.3)
     transitivePeerDependencies:
       - supports-color
@@ -5999,7 +6110,7 @@ snapshots:
     dependencies:
       '@babel/code-frame': 7.29.7
       chalk: 4.1.2
-      js-yaml: 4.3.0
+      js-yaml: 4.2.0
 
   '@humanfs/core@0.19.2':
     dependencies:
@@ -6038,7 +6149,7 @@ snapshots:
       jest-util: 29.7.0
       slash: 3.0.0
 
-  '@jest/core@29.7.0':
+  '@jest/core@29.7.0(ts-node@10.9.2(@types/node@26.1.1)(typescript@6.0.3))':
     dependencies:
       '@jest/console': 29.7.0
       '@jest/reporters': 29.7.0
@@ -6052,7 +6163,7 @@ snapshots:
       exit: 0.1.2
       graceful-fs: 4.2.11
       jest-changed-files: 29.7.0
-      jest-config: 29.7.0(@types/node@26.1.1)
+      jest-config: 29.7.0(@types/node@26.1.1)(ts-node@10.9.2(@types/node@26.1.1)(typescript@6.0.3))
       jest-haste-map: 29.7.0
       jest-message-util: 29.7.0
       jest-regex-util: 29.6.3
@@ -6226,6 +6337,12 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@jridgewell/trace-mapping@0.3.9':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.5
+    optional: true
 
   '@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
     dependencies:
@@ -6611,7 +6728,7 @@ snapshots:
       picocolors: 1.1.1
       redent: 3.0.0
 
-  '@testing-library/react-native@14.0.1(jest@29.7.0(@types/node@26.1.1))(react-native@0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3))(react@19.2.3)(test-renderer@1.2.0(@types/react@19.2.17)(react@19.2.3))':
+  '@testing-library/react-native@14.0.1(jest@29.7.0(@types/node@26.1.1)(ts-node@10.9.2(@types/node@26.1.1)(typescript@6.0.3)))(react-native@0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3))(react@19.2.3)(test-renderer@1.2.0(@types/react@19.2.17)(react@19.2.3))':
     dependencies:
       jest-matcher-utils: 30.4.1
       picocolors: 1.1.1
@@ -6621,13 +6738,25 @@ snapshots:
       redent: 3.0.0
       test-renderer: 1.2.0(@types/react@19.2.17)(react@19.2.3)
     optionalDependencies:
-      jest: 29.7.0(@types/node@26.1.1)
+      jest: 29.7.0(@types/node@26.1.1)(ts-node@10.9.2(@types/node@26.1.1)(typescript@6.0.3))
 
   '@testing-library/user-event@14.6.1(@testing-library/dom@10.4.1)':
     dependencies:
       '@testing-library/dom': 10.4.1
 
   '@tootallnate/once@2.0.1': {}
+
+  '@tsconfig/node10@1.0.12':
+    optional: true
+
+  '@tsconfig/node12@1.0.11':
+    optional: true
+
+  '@tsconfig/node14@1.0.3':
+    optional: true
+
+  '@tsconfig/node16@1.0.4':
+    optional: true
 
   '@turbo/darwin-64@2.10.5':
     optional: true
@@ -6942,12 +7071,23 @@ snapshots:
 
   agent-cli-detector@0.1.4: {}
 
+  ajv-formats@3.0.1(ajv@8.18.0):
+    optionalDependencies:
+      ajv: 8.18.0
+
   ajv@6.15.0:
     dependencies:
       fast-deep-equal: 3.1.3
       fast-json-stable-stringify: 2.1.0
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
+
+  ajv@8.18.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-uri: 3.1.4
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
 
   anser@1.4.10: {}
 
@@ -6977,6 +7117,8 @@ snapshots:
     dependencies:
       normalize-path: 3.0.0
       picomatch: 2.3.2
+
+  arg@4.1.3: {}
 
   arg@5.0.2: {}
 
@@ -7434,13 +7576,13 @@ snapshots:
     dependencies:
       browserslist: 4.28.6
 
-  create-jest@29.7.0(@types/node@26.1.1):
+  create-jest@29.7.0(@types/node@26.1.1)(ts-node@10.9.2(@types/node@26.1.1)(typescript@6.0.3)):
     dependencies:
       '@jest/types': 29.6.3
       chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.11
-      jest-config: 29.7.0(@types/node@26.1.1)
+      jest-config: 29.7.0(@types/node@26.1.1)(ts-node@10.9.2(@types/node@26.1.1)(typescript@6.0.3))
       jest-util: 29.7.0
       prompts: 2.4.2
     transitivePeerDependencies:
@@ -7448,6 +7590,9 @@ snapshots:
       - babel-plugin-macros
       - supports-color
       - ts-node
+
+  create-require@1.1.1:
+    optional: true
 
   cross-fetch@3.2.0:
     dependencies:
@@ -7554,6 +7699,9 @@ snapshots:
   detect-node-es@1.1.0: {}
 
   diff-sequences@29.6.3: {}
+
+  diff@4.0.4:
+    optional: true
 
   dnssd-advertise@1.1.6: {}
 
@@ -8006,6 +8154,8 @@ snapshots:
 
   expo-doctor@1.20.1: {}
 
+  expo-eas-client@57.0.1: {}
+
   expo-file-system@57.0.1(expo@57.0.7)(react-native@0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3)):
     dependencies:
       expo: 57.0.7(@babel/core@7.29.7)(@expo/dom-webview@57.0.1)(@expo/metro-runtime@57.0.6)(expo-router@57.0.7)(react-dom@19.2.3(react@19.2.3))(react-native-web@0.21.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-native-worklets@0.10.0(@babel/core@7.29.7)(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(react-native@0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3))(react@19.2.3))(react-native@0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3))(react@19.2.3)(typescript@6.0.3)
@@ -8070,7 +8220,7 @@ snapshots:
     dependencies:
       react-native: 0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3)
 
-  expo-router@57.0.7(1743bdfbd8e1512c8e24536b8defc5c8):
+  expo-router@57.0.7(0b23e7d965b558fa330d3fabed921333):
     dependencies:
       '@expo/log-box': 57.0.1(@expo/dom-webview@57.0.1)(expo@57.0.7)(react-native@0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3))(react@19.2.3)
       '@expo/metro-runtime': 57.0.6(@expo/log-box@57.0.1)(expo@57.0.7)(react-dom@19.2.3(react@19.2.3))(react-native@0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3))(react@19.2.3)
@@ -8108,7 +8258,7 @@ snapshots:
       standard-navigation: 0.0.5
       vaul: 1.1.2(@types/react@19.2.17)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
     optionalDependencies:
-      '@testing-library/react-native': 14.0.1(jest@29.7.0(@types/node@26.1.1))(react-native@0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3))(react@19.2.3)(test-renderer@1.2.0(@types/react@19.2.17)(react@19.2.3))
+      '@testing-library/react-native': 14.0.1(jest@29.7.0(@types/node@26.1.1)(ts-node@10.9.2(@types/node@26.1.1)(typescript@6.0.3)))(react-native@0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3))(react@19.2.3)(test-renderer@1.2.0(@types/react@19.2.17)(react@19.2.3))
       react-dom: 19.2.3(react@19.2.3)
       react-native-gesture-handler: 2.32.0(react-native@0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3))(react@19.2.3)
       react-native-reanimated: 4.5.0(react-native-worklets@0.10.0(@babel/core@7.29.7)(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(react-native@0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3))(react@19.2.3))(react-native@0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3))(react@19.2.3)
@@ -8140,6 +8290,8 @@ snapshots:
       react: 19.2.3
       react-native: 0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3)
 
+  expo-structured-headers@57.0.0: {}
+
   expo-symbols@57.0.1(expo-font@57.0.1)(expo@57.0.7)(react-native@0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3))(react@19.2.3):
     dependencies:
       '@expo-google-fonts/material-symbols': 0.4.41
@@ -8163,6 +8315,31 @@ snapshots:
   expo-updates-interface@57.0.1(expo@57.0.7):
     dependencies:
       expo: 57.0.7(@babel/core@7.29.7)(@expo/dom-webview@57.0.1)(@expo/metro-runtime@57.0.6)(expo-router@57.0.7)(react-dom@19.2.3(react@19.2.3))(react-native-web@0.21.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-native-worklets@0.10.0(@babel/core@7.29.7)(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(react-native@0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3))(react@19.2.3))(react-native@0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3))(react@19.2.3)(typescript@6.0.3)
+
+  expo-updates@57.0.8(expo-dev-client@57.0.7(expo@57.0.7)(react-native@0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3)))(expo@57.0.7)(react-native@0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3))(react@19.2.3):
+    dependencies:
+      '@expo/code-signing-certificates': 0.0.6
+      '@expo/plist': 0.8.1
+      '@expo/spawn-async': 1.8.0
+      arg: 4.1.3
+      chalk: 4.1.2
+      debug: 4.4.3
+      expo: 57.0.7(@babel/core@7.29.7)(@expo/dom-webview@57.0.1)(@expo/metro-runtime@57.0.6)(expo-router@57.0.7)(react-dom@19.2.3(react@19.2.3))(react-native-web@0.21.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-native-worklets@0.10.0(@babel/core@7.29.7)(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(react-native@0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3))(react@19.2.3))(react-native@0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3))(react@19.2.3)(typescript@6.0.3)
+      expo-eas-client: 57.0.1
+      expo-manifests: 57.0.1(expo@57.0.7)
+      expo-structured-headers: 57.0.0
+      expo-updates-interface: 57.0.1(expo@57.0.7)
+      getenv: 2.0.0
+      glob: 13.0.6
+      ignore: 5.3.2
+      nullthrows: 1.1.1
+      react: 19.2.3
+      react-native: 0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3)
+      resolve-from: 5.0.0
+    optionalDependencies:
+      expo-dev-client: 57.0.7(expo@57.0.7)(react-native@0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3))
+    transitivePeerDependencies:
+      - supports-color
 
   expo@57.0.7(@babel/core@7.29.7)(@expo/dom-webview@57.0.1)(@expo/metro-runtime@57.0.6)(expo-router@57.0.7)(react-dom@19.2.3(react@19.2.3))(react-native-web@0.21.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-native-worklets@0.10.0(@babel/core@7.29.7)(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(react-native@0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3))(react@19.2.3))(react-native@0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3))(react@19.2.3)(typescript@6.0.3):
     dependencies:
@@ -8213,6 +8390,8 @@ snapshots:
   fast-json-stable-stringify@2.1.0: {}
 
   fast-levenshtein@2.0.6: {}
+
+  fast-uri@3.1.4: {}
 
   fb-dotslash@0.5.8: {}
 
@@ -8768,16 +8947,16 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-cli@29.7.0(@types/node@26.1.1):
+  jest-cli@29.7.0(@types/node@26.1.1)(ts-node@10.9.2(@types/node@26.1.1)(typescript@6.0.3)):
     dependencies:
-      '@jest/core': 29.7.0
+      '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@26.1.1)(typescript@6.0.3))
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
       chalk: 4.1.2
-      create-jest: 29.7.0(@types/node@26.1.1)
+      create-jest: 29.7.0(@types/node@26.1.1)(ts-node@10.9.2(@types/node@26.1.1)(typescript@6.0.3))
       exit: 0.1.2
       import-local: 3.2.0
-      jest-config: 29.7.0(@types/node@26.1.1)
+      jest-config: 29.7.0(@types/node@26.1.1)(ts-node@10.9.2(@types/node@26.1.1)(typescript@6.0.3))
       jest-util: 29.7.0
       jest-validate: 29.7.0
       yargs: 17.7.3
@@ -8787,7 +8966,7 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-config@29.7.0(@types/node@26.1.1):
+  jest-config@29.7.0(@types/node@26.1.1)(ts-node@10.9.2(@types/node@26.1.1)(typescript@6.0.3)):
     dependencies:
       '@babel/core': 7.29.7
       '@jest/test-sequencer': 29.7.0
@@ -8813,6 +8992,7 @@ snapshots:
       strip-json-comments: 3.1.1
     optionalDependencies:
       '@types/node': 26.1.1
+      ts-node: 10.9.2(@types/node@26.1.1)(typescript@6.0.3)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -8867,7 +9047,7 @@ snapshots:
       jest-mock: 29.7.0
       jest-util: 29.7.0
 
-  jest-expo@57.0.2(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(expo@57.0.7)(jest@29.7.0(@types/node@26.1.1))(react-native@0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3))(react@19.2.3):
+  jest-expo@57.0.2(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(expo@57.0.7)(jest@29.7.0(@types/node@26.1.1)(ts-node@10.9.2(@types/node@26.1.1)(typescript@6.0.3)))(react-native@0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3))(react@19.2.3):
     dependencies:
       '@jest/create-cache-key-function': 29.7.0
       '@jest/globals': 29.7.0
@@ -8876,7 +9056,7 @@ snapshots:
       jest-environment-jsdom: 29.7.0
       jest-snapshot: 29.7.0
       jest-watch-select-projects: 2.0.0
-      jest-watch-typeahead: 2.2.1(jest@29.7.0(@types/node@26.1.1))
+      jest-watch-typeahead: 2.2.1(jest@29.7.0(@types/node@26.1.1)(ts-node@10.9.2(@types/node@26.1.1)(typescript@6.0.3)))
       json5: 2.2.3
       lodash: 4.18.1
       react-native: 0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3)
@@ -9076,11 +9256,11 @@ snapshots:
       chalk: 3.0.0
       prompts: 2.4.2
 
-  jest-watch-typeahead@2.2.1(jest@29.7.0(@types/node@26.1.1)):
+  jest-watch-typeahead@2.2.1(jest@29.7.0(@types/node@26.1.1)(ts-node@10.9.2(@types/node@26.1.1)(typescript@6.0.3))):
     dependencies:
       ansi-escapes: 6.2.1
       chalk: 4.1.2
-      jest: 29.7.0(@types/node@26.1.1)
+      jest: 29.7.0(@types/node@26.1.1)(ts-node@10.9.2(@types/node@26.1.1)(typescript@6.0.3))
       jest-regex-util: 29.6.3
       jest-watcher: 29.7.0
       slash: 5.1.0
@@ -9105,12 +9285,12 @@ snapshots:
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
-  jest@29.7.0(@types/node@26.1.1):
+  jest@29.7.0(@types/node@26.1.1)(ts-node@10.9.2(@types/node@26.1.1)(typescript@6.0.3)):
     dependencies:
-      '@jest/core': 29.7.0
+      '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@26.1.1)(typescript@6.0.3))
       '@jest/types': 29.6.3
       import-local: 3.2.0
-      jest-cli: 29.7.0(@types/node@26.1.1)
+      jest-cli: 29.7.0(@types/node@26.1.1)(ts-node@10.9.2(@types/node@26.1.1)(typescript@6.0.3))
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -9125,6 +9305,10 @@ snapshots:
     dependencies:
       argparse: 1.0.10
       esprima: 4.0.1
+
+  js-yaml@4.2.0:
+    dependencies:
+      argparse: 2.0.1
 
   js-yaml@4.3.0:
     dependencies:
@@ -9172,6 +9356,8 @@ snapshots:
   json-parse-even-better-errors@2.3.1: {}
 
   json-schema-traverse@0.4.1: {}
+
+  json-schema-traverse@1.0.0: {}
 
   json-stable-stringify-without-jsonify@1.0.1: {}
 
@@ -10097,6 +10283,8 @@ snapshots:
 
   require-directory@2.1.1: {}
 
+  require-from-string@2.0.2: {}
+
   requires-port@1.0.0: {}
 
   resolve-cwd@3.0.0:
@@ -10520,12 +10708,12 @@ snapshots:
     dependencies:
       typescript: 6.0.3
 
-  ts-jest@29.4.11(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.7))(jest-util@29.7.0)(jest@29.7.0(@types/node@26.1.1))(typescript@6.0.3):
+  ts-jest@29.4.11(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.7))(jest-util@29.7.0)(jest@29.7.0(@types/node@26.1.1)(ts-node@10.9.2(@types/node@26.1.1)(typescript@6.0.3)))(typescript@6.0.3):
     dependencies:
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
       handlebars: 4.7.9
-      jest: 29.7.0(@types/node@26.1.1)
+      jest: 29.7.0(@types/node@26.1.1)(ts-node@10.9.2(@types/node@26.1.1)(typescript@6.0.3))
       json5: 2.2.3
       lodash.memoize: 4.1.2
       make-error: 1.3.6
@@ -10539,6 +10727,25 @@ snapshots:
       '@jest/types': 29.6.3
       babel-jest: 29.7.0(@babel/core@7.29.7)
       jest-util: 29.7.0
+
+  ts-node@10.9.2(@types/node@26.1.1)(typescript@6.0.3):
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      '@tsconfig/node10': 1.0.12
+      '@tsconfig/node12': 1.0.11
+      '@tsconfig/node14': 1.0.3
+      '@tsconfig/node16': 1.0.4
+      '@types/node': 26.1.1
+      acorn: 8.17.0
+      acorn-walk: 8.3.5
+      arg: 4.1.3
+      create-require: 1.1.1
+      diff: 4.0.4
+      make-error: 1.3.6
+      typescript: 6.0.3
+      v8-compile-cache-lib: 3.0.1
+      yn: 3.1.1
+    optional: true
 
   tsconfig-paths@3.15.0:
     dependencies:
@@ -10698,6 +10905,9 @@ snapshots:
   utils-merge@1.0.1: {}
 
   uuid@11.1.1: {}
+
+  v8-compile-cache-lib@3.0.1:
+    optional: true
 
   v8-to-istanbul@9.3.0:
     dependencies:
@@ -10859,6 +11069,9 @@ snapshots:
       string-width: 4.2.3
       y18n: 5.0.8
       yargs-parser: 21.1.1
+
+  yn@3.1.1:
+    optional: true
 
   yocto-queue@0.1.0: {}
 

--- a/scripts/architecture.test.mjs
+++ b/scripts/architecture.test.mjs
@@ -1,0 +1,20 @@
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import test from 'node:test';
+import { ESLint } from 'eslint';
+
+const repositoryRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+
+test('shared packages cannot deep-import another workspace package', async () => {
+  const eslint = new ESLint({ cwd: repositoryRoot });
+  const [result] = await eslint.lintText(
+    "import { Button } from '@starter/ui/button';\nexport { Button };\n",
+    {
+      filePath: path.join(repositoryRoot, 'packages/theme/src/example.ts'),
+    }
+  );
+
+  assert.ok(result);
+  assert.ok(result.messages.some((message) => message.ruleId === 'no-restricted-imports'));
+});

--- a/scripts/initialize-template.mjs
+++ b/scripts/initialize-template.mjs
@@ -180,8 +180,8 @@ async function replaceInTextFiles(directory, replacements, changedFiles) {
   }
 }
 
-function replaceConfigFallback(source, environmentName, value) {
-  const expression = new RegExp(`(process\\.env\\.${environmentName} \\?\\? ')[^']+(')`);
+function replaceStringProperty(source, propertyName, value) {
+  const expression = new RegExp(`(${propertyName}: ')[^']+(')`);
   return source.replace(expression, `$1${value}$2`);
 }
 
@@ -230,16 +230,17 @@ await writeIfChanged(
   changedFiles
 );
 
-const appConfigPath = path.join(root, 'apps/mobile-app/app.config.ts');
-let appConfig = await readFile(appConfigPath, 'utf8');
-appConfig = replaceConfigFallback(appConfig, 'APP_NAME', values.appName);
-appConfig = replaceConfigFallback(appConfig, 'APP_SLUG', values.appSlug);
-appConfig = replaceConfigFallback(appConfig, 'APP_SCHEME', values.appScheme);
-appConfig = replaceConfigFallback(appConfig, 'IOS_BUNDLE_IDENTIFIER', values.iosBundleId);
-appConfig = replaceConfigFallback(appConfig, 'ANDROID_PACKAGE', values.androidPackage);
-await writeIfChanged(appConfigPath, appConfig, changedFiles);
+const appIdentityPath = path.join(root, 'apps/mobile-app/app.config.ts');
+let appIdentity = await readFile(appIdentityPath, 'utf8');
+appIdentity = replaceStringProperty(appIdentity, 'appName', values.appName);
+appIdentity = replaceStringProperty(appIdentity, 'appSlug', values.appSlug);
+appIdentity = replaceStringProperty(appIdentity, 'appScheme', values.appScheme);
+appIdentity = replaceStringProperty(appIdentity, 'iosBundleIdentifier', values.iosBundleId);
+appIdentity = replaceStringProperty(appIdentity, 'androidPackage', values.androidPackage);
+await writeIfChanged(appIdentityPath, appIdentity, changedFiles);
 
 const appNameFiles = [
+  'apps/mobile-app/.maestro/smoke.yml',
   'apps/mobile-app/src/screens/home/home-screen.tsx',
   'apps/mobile-app/src/screens/home/home-screen.test.tsx',
 ];
@@ -260,6 +261,7 @@ const nextEnvironment = [
   `APP_SCHEME=${values.appScheme}`,
   `IOS_BUNDLE_IDENTIFIER=${values.iosBundleId}`,
   `ANDROID_PACKAGE=${values.androidPackage}`,
+  '# APP_ENV=development',
   '# EAS_PROJECT_ID=',
   '',
 ].join('\n');
@@ -267,8 +269,17 @@ await writeIfChanged(environmentPath, nextEnvironment, changedFiles);
 
 const initializationRecordPath = path.join(root, '.template-initialized.json');
 const initializationRecord = `${JSON.stringify(
-  values,
-  ['repoName', 'scope', 'appName', 'appSlug', 'appScheme', 'iosBundleId', 'androidPackage'],
+  { templateVersion: rootPackage.version, ...values },
+  [
+    'templateVersion',
+    'repoName',
+    'scope',
+    'appName',
+    'appSlug',
+    'appScheme',
+    'iosBundleId',
+    'androidPackage',
+  ],
   2
 )}\n`;
 

--- a/scripts/initialize-template.test.mjs
+++ b/scripts/initialize-template.test.mjs
@@ -1,0 +1,100 @@
+import assert from 'node:assert/strict';
+import { execFile } from 'node:child_process';
+import { cp, mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { promisify } from 'node:util';
+import { fileURLToPath } from 'node:url';
+import test from 'node:test';
+
+const execFileAsync = promisify(execFile);
+const repositoryRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const generatedDirectoryNames = new Set([
+  '.expo',
+  '.git',
+  '.turbo',
+  'android',
+  'coverage',
+  'dist',
+  'ios',
+  'node_modules',
+]);
+
+async function createTemplateCopy() {
+  const parentDirectory = await mkdtemp(path.join(tmpdir(), 'expo-turbo-initializer-'));
+  const workspace = path.join(parentDirectory, 'workspace');
+
+  await cp(repositoryRoot, workspace, {
+    recursive: true,
+    filter: (source) => !generatedDirectoryNames.has(path.basename(source)),
+  });
+
+  return { parentDirectory, workspace };
+}
+
+async function readJson(filePath) {
+  return JSON.parse(await readFile(filePath, 'utf8'));
+}
+
+async function initialize(workspace) {
+  return execFileAsync(
+    process.execPath,
+    [
+      'scripts/initialize-template.mjs',
+      '--yes',
+      '--repo-name',
+      'acme-mobile',
+      '--scope',
+      '@acme',
+      '--app-name',
+      'Acme Mobile',
+      '--app-slug',
+      'acme-mobile',
+      '--app-scheme',
+      'acme-mobile',
+      '--ios-bundle-id',
+      'com.acme.mobile',
+      '--android-package',
+      'com.acme.mobile',
+    ],
+    { cwd: workspace }
+  );
+}
+
+test('records the template version when initializing a new project', async (context) => {
+  const { parentDirectory, workspace } = await createTemplateCopy();
+  context.after(() => rm(parentDirectory, { force: true, recursive: true }));
+
+  const sourceManifest = await readJson(path.join(workspace, 'package.json'));
+
+  await initialize(workspace);
+
+  const initializationRecord = await readJson(path.join(workspace, '.template-initialized.json'));
+
+  assert.equal(initializationRecord.templateVersion, sourceManifest.version);
+});
+
+test('updates the app identity defaults used by Expo configuration', async (context) => {
+  const { parentDirectory, workspace } = await createTemplateCopy();
+  context.after(() => rm(parentDirectory, { force: true, recursive: true }));
+
+  await initialize(workspace);
+
+  const appIdentitySource = await readFile(
+    path.join(workspace, 'apps/mobile-app/app.config.ts'),
+    'utf8'
+  );
+
+  assert.match(appIdentitySource, /androidPackage: 'com\.acme\.mobile'/);
+  assert.match(appIdentitySource, /iosBundleIdentifier: 'com\.acme\.mobile'/);
+  assert.doesNotMatch(appIdentitySource, /com\.example\.expoturbostarter/);
+
+  const smokeFlow = await readFile(
+    path.join(workspace, 'apps/mobile-app/.maestro/smoke.yml'),
+    'utf8'
+  );
+  assert.match(smokeFlow, /assertVisible: 'Acme Mobile'/);
+
+  const environmentExample = await readFile(path.join(workspace, '.env.example'), 'utf8');
+  assert.match(environmentExample, /# APP_ENV=development/);
+});

--- a/scripts/validate-eas-workflows.mjs
+++ b/scripts/validate-eas-workflows.mjs
@@ -1,0 +1,36 @@
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+
+import Ajv2020 from 'ajv/dist/2020.js';
+import addFormats from 'ajv-formats';
+import { load as loadYaml } from 'js-yaml';
+
+const schemaUrl = 'https://api.expo.dev/v2/workflows/schema';
+const workflowFiles = process.argv.slice(2);
+
+if (workflowFiles.length === 0) {
+  throw new Error('Provide at least one EAS workflow file to validate.');
+}
+
+const response = await fetch(schemaUrl);
+
+if (!response.ok) {
+  throw new Error(`Could not fetch the EAS workflow schema (${response.status}).`);
+}
+
+const body = await response.json();
+const ajv = new Ajv2020({ allErrors: true, strict: true });
+addFormats(ajv);
+const validate = ajv.compile(body.data);
+
+for (const workflowFile of workflowFiles) {
+  const source = await readFile(path.resolve(workflowFile), 'utf8');
+  const workflow = loadYaml(source);
+
+  if (!validate(workflow)) {
+    const details = ajv.errorsText(validate.errors, { separator: '\n' });
+    throw new Error(`${workflowFile} does not match the current EAS workflow schema:\n${details}`);
+  }
+
+  console.log(`Validated ${workflowFile}`);
+}

--- a/scripts/verify-template.mjs
+++ b/scripts/verify-template.mjs
@@ -1,0 +1,104 @@
+import assert from 'node:assert/strict';
+import { execFile, spawn } from 'node:child_process';
+import { cp, mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { promisify } from 'node:util';
+import { fileURLToPath } from 'node:url';
+
+const execFileAsync = promisify(execFile);
+const repositoryRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const generatedDirectoryNames = new Set([
+  '.expo',
+  '.git',
+  '.turbo',
+  'android',
+  'coverage',
+  'dist',
+  'ios',
+  'node_modules',
+]);
+const initializationArguments = [
+  'scripts/initialize-template.mjs',
+  '--yes',
+  '--repo-name',
+  'canary-mobile',
+  '--scope',
+  '@canary',
+  '--app-name',
+  'Canary Mobile',
+  '--app-slug',
+  'canary-mobile',
+  '--app-scheme',
+  'canary-mobile',
+  '--ios-bundle-id',
+  'com.canary.mobile',
+  '--android-package',
+  'com.canary.mobile',
+];
+
+function run(command, arguments_, cwd) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, arguments_, {
+      cwd,
+      env: { ...process.env, CI: 'true' },
+      stdio: 'inherit',
+    });
+
+    child.once('error', reject);
+    child.once('exit', (code, signal) => {
+      if (code === 0) {
+        resolve();
+        return;
+      }
+
+      reject(new Error(`${command} exited with ${code ?? signal ?? 'an unknown status'}.`));
+    });
+  });
+}
+
+const temporaryParent = await mkdtemp(path.join(tmpdir(), 'expo-turbo-canary-'));
+const workspace = path.join(temporaryParent, 'workspace');
+
+try {
+  await cp(repositoryRoot, workspace, {
+    recursive: true,
+    filter: (source) => !generatedDirectoryNames.has(path.basename(source)),
+  });
+
+  await run(process.execPath, initializationArguments, workspace);
+
+  const secondInitialization = await execFileAsync(process.execPath, initializationArguments, {
+    cwd: workspace,
+  });
+  assert.match(secondInitialization.stdout, /Template already matches the requested configuration/);
+
+  const initializationRecord = JSON.parse(
+    await readFile(path.join(workspace, '.template-initialized.json'), 'utf8')
+  );
+  const sourceManifest = JSON.parse(
+    await readFile(path.join(repositoryRoot, 'package.json'), 'utf8')
+  );
+  const appIdentitySource = await readFile(
+    path.join(workspace, 'apps/mobile-app/app.config.ts'),
+    'utf8'
+  );
+
+  assert.equal(initializationRecord.scope, '@canary');
+  assert.equal(initializationRecord.templateVersion, sourceManifest.version);
+  assert.doesNotMatch(appIdentitySource, /com\.example\.expoturbostarter/);
+
+  await run('pnpm', ['install', '--frozen-lockfile'], workspace);
+  await run('pnpm', ['check'], workspace);
+  await run('pnpm', ['expo:doctor'], workspace);
+  await run('pnpm', ['export:web'], workspace);
+  await run(
+    'pnpm',
+    ['--dir', 'apps/mobile-app', 'exec', 'expo', 'prebuild', '--no-install', '--clean'],
+    workspace
+  );
+
+  console.log('Generated-template canary passed.');
+} finally {
+  await rm(temporaryParent, { force: true, recursive: true });
+}


### PR DESCRIPTION
## Summary

- fail production config closed on placeholder app identity and add fingerprint-based updates
- add a tested root recovery boundary with a provider-neutral, failure-isolated reporting seam
- pin CI actions, enforce toolchain and package boundaries, add coverage, dependency, workflow, template-canary, Android, and iOS checks
- add manual EAS production delivery and dual-platform Maestro smoke workflows validated against the live Expo schema
- establish a versioned starter maintenance contract with release and upgrade documentation

## Verification

- `pnpm check`
- `pnpm test:coverage`
- `pnpm expo:doctor` (20/20)
- `pnpm check:workflows`
- `pnpm export:web`
- `pnpm audit --audit-level moderate` (no known vulnerabilities)
- `pnpm verify:template`

The EAS delivery workflows remain manual and were not dispatched because this template repository is intentionally not linked to an EAS project or store credentials. The pull request native workflow compiles Android and iOS on GitHub for this diff.